### PR TITLE
Adds a show-all button when there are no recently expiring certs

### DIFF
--- a/web/build/doomsday.js
+++ b/web/build/doomsday.js
@@ -287,9 +287,11 @@ class DashboardPage extends PageBase {
         }
         if (lists.length == 0) {
             this.certsElement.template("no-certs-page");
-            return;
         }
-        this.certsElement.template("cert-list-group", { lists: lists });
+        else {
+            this.certsElement.template("cert-list-group", { lists: lists });
+            this.certsElement.show();
+        }
         this.showMoreButton = $("#certs-show-more");
         this.showMoreButton.on("click", (e) => {
             e.preventDefault();
@@ -302,7 +304,7 @@ class DashboardPage extends PageBase {
             this.showMoreButton.prop("disabled", false);
             return false;
         });
-        this.certsElement.show();
+        return;
     }
     durationString(days) {
         if (days < 0) {

--- a/web/index.html
+++ b/web/index.html
@@ -66,6 +66,9 @@
 		    No Certificates Are Expiring Soon
 			</div>
 		</div>
+		<div class="center-box">
+			<button id="certs-show-more" style="position:relative;top:30vh">show all</button>
+		</div>
 	</script>
 
 	<script type="text/html" id="template:cert-card-header">

--- a/web/ts/pages/certs.ts
+++ b/web/ts/pages/certs.ts
@@ -68,10 +68,10 @@ class DashboardPage extends PageBase {
 
     if (lists.length == 0) {
       this.certsElement.template("no-certs-page");
-      return;
+    } else {
+      this.certsElement.template("cert-list-group", { lists: lists });
+      this.certsElement.show();
     }
-
-    this.certsElement.template("cert-list-group", { lists: lists });
     this.showMoreButton = $("#certs-show-more");
     this.showMoreButton.on("click", (e: JQuery.Event) => {
       e.preventDefault();
@@ -84,7 +84,7 @@ class DashboardPage extends PageBase {
       this.showMoreButton.prop("disabled", false);
       return false;
     })
-    this.certsElement.show();
+    return;
   }
 
 


### PR DESCRIPTION
This could likely be done cleaner (without the inline style)
if the no-certs-container didnt have odd things happening with
the parent height (the child element is outside the parent height).